### PR TITLE
Sample splitting superlearner

### DIFF
--- a/R/aipw.R
+++ b/R/aipw.R
@@ -139,8 +139,8 @@ aipw <- function(aipw_input=NULL,tmle_fit=NULL,A=NULL,Y=NULL){
                                    *mean(1-aipw_eif1)*mean(1-aipw_eif0))))/Z_norm
   aipw_OR.ci <- ci(aipw_OR,se_OR,ratio=T)
 
-  res <- matrix(c(aipw_RD,se_RD,aipw_RD.ci,aipw_RR,se_RR,aipw_RR.ci,aipw_OR,se_OR,aipw_OR.ci),nrow=3,byrow=T)
-  colnames(res) <- c("Estimate","SE","95% LCL","95% UCL")
+  res <- matrix(c(aipw_RD,se_RD,aipw_RD.ci,N,aipw_RR,se_RR,aipw_RR.ci,N,aipw_OR,se_OR,aipw_OR.ci,N),nrow=3,byrow=T)
+  colnames(res) <- c("Estimate","SE","95% LCL","95% UCL","N")
   row.names(res) <- c("Risk Difference","Risk Ratio", "Odds Ratio")
   return(res)
 }

--- a/R/aipw.R
+++ b/R/aipw.R
@@ -139,6 +139,8 @@ aipw <- function(aipw_input=NULL,tmle_fit=NULL,A=NULL,Y=NULL){
                                    *mean(1-aipw_eif1)*mean(1-aipw_eif0))))/Z_norm
   aipw_OR.ci <- ci(aipw_OR,se_OR,ratio=T)
 
+  N <- length(aipw_eif1)
+
   res <- matrix(c(aipw_RD,se_RD,aipw_RD.ci,N,aipw_RR,se_RR,aipw_RR.ci,N,aipw_OR,se_OR,aipw_OR.ci,N),nrow=3,byrow=T)
   colnames(res) <- c("Estimate","SE","95% LCL","95% UCL","N")
   row.names(res) <- c("Risk Difference","Risk Ratio", "Odds Ratio")

--- a/R/aipw.R
+++ b/R/aipw.R
@@ -72,7 +72,10 @@ aipw_input <- function(Y,A,W,Q.SL.library,g.SL.library,k_split=1,verbose=FALSE){
 
   aipw_input_value <- matrix(c(aipw_eif1,aipw_eif0),ncol=2)
   colnames(aipw_input_value) <- c("aipw_eif1","aipw_eif0")
-  return(aipw_input_value)
+
+  res <- list(aipw_input_value,g_fit,Q_fit)
+
+  return(res)
 }
 
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Augmented inverse probability weighting (AIPW) for binary exposure and outcome
 
 ``` r
 install.packages("remotes")
-remotes::install_github("yqzhong7/AIPW")
+remotes::install_github("yqzhong7/AIPW",ref="sample-splitting-superlearner")
 ```
 
 ## Example


### PR DESCRIPTION
made several minor changes, including adding sample size to aipw output and enabling code to handle non-overlapping covariate sets for exposure and outcome models. I also fixed the R code in the readme file: the "remotes:: ... " line was not downloading the branch, but rather the master. Some remaining issues:

1) currently, we cannot but a single column from a data.frame into the W.Q or W.g arguments
2) I think their may be a problem with the SEs for risk ratio and odds ratio, they are too large to believe, IMO.